### PR TITLE
Addon improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
 /dist
@@ -13,5 +13,5 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
-npm-debug.log
+npm-debug.log*
 testem.log

--- a/.jshintrc
+++ b/.jshintrc
@@ -27,6 +27,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "unused": true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
 
 sudo: false
 
 cache:
   directories:
-    - node_modules
+    - $HOME/.npm
+    - $HOME/.cache # includes bowers cache
 
 env:
-  - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-1-13
+  # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
+  - EMBER_TRY_SCENARIO=ember-lts-2.4
+  - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
@@ -22,14 +24,17 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
-  - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - npm config set spin false
+  - npm install -g bower
+  - bower --version
+  - npm install phantomjs-prebuilt
+  - node_modules/phantomjs-prebuilt/bin/phantomjs --version
 
 install:
-  - npm install -g bower
   - npm install
   - bower install
 
 script:
-  - ember try $EMBER_TRY_SCENARIO test
+  # Usually, it's ok to finish the test scenario without reverting
+  #  to the addon's original dependency state, skipping "cleanup".
+  - ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # ember-cli-nprogress
+
 This ember-cli addon simplifies integration of NProgress plugin with ember-cli apps.
 
 ## Installation
-* ember install ember-cli-nprogress
+
+```bash
+ember install ember-cli-nprogress
+```
+
+**Note:** Version `2.9.0` or higher of the Ember CLI is required
 
 ## Usage
-<pre>
-<code>
+
+```javascript
 import Ember from 'ember';
 import progress from 'ember-cli-nprogress';
 
@@ -21,23 +27,8 @@ export default Ember.Route.extend({
     });
   }
 });
-</code>
-</pre>
-
-## Running
-* `ember server`
-* Visit your app at http://localhost:4200.
-
-## Running Tests
-* `npm test` (Runs `ember try:testall` to test your addon against multiple Ember versions)
-* `ember test`
-* `ember test --server`
-
-## Building
-* `ember build`
-
-For more information on using ember-cli, visit [http://www.ember-cli.com/](http://www.ember-cli.com/).
-
+```
 
 ## API
+
 See [rstacruz/nprogress](https://github.com/rstacruz/nprogress) for details.

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,1 +1,1 @@
-export default window.NProgress;
+export { default } from 'nprogress';

--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
     "ember": "~2.4.1",
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0"
+    "ember-qunit-notifications": "0.1.0",
+    "nprogress": "^0.2.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,8 @@
 {
   "name": "ember-cli-nprogress",
   "dependencies": {
-    "ember": "~2.4.1",
-    "ember-cli-shims": "0.1.0",
-    "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0",
+    "ember": "~2.10.0",
+    "ember-cli-shims": "0.1.3",
     "nprogress": "^0.2.0"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,19 +2,24 @@
 module.exports = {
   scenarios: [
     {
-      name: 'default',
+      name: 'ember-lts-2.4',
       bower: {
-        dependencies: { }
+        dependencies: {
+          'ember': 'components/ember#lts-2-4'
+        },
+        resolutions: {
+          'ember': 'lts-2-4'
+        }
       }
     },
     {
-      name: 'ember-1-13',
+      name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          'ember': '~1.13.0'
+          'ember': 'components/ember#lts-2-8'
         },
         resolutions: {
-          'ember': '~1.13.0'
+          'ember': 'lts-2-8'
         }
       }
     },

--- a/index.js
+++ b/index.js
@@ -1,14 +1,19 @@
 /* jshint node: true */
 'use strict';
 
+var debug = require('debug')('ember-cli-nprogress:addon');
+
 module.exports = {
   name: 'ember-cli-nprogress',
 
   included: function(app) {
     this._super.included(app);
-    this.ui.writeLine('Importing NProgress files!');
+
+    debug('Importing NProgress files!');
+
     app.import(app.bowerDirectory + '/nprogress/nprogress.js');
     app.import(app.bowerDirectory + '/nprogress/nprogress.css');
-    this.ui.writeLine('Imported NProgress files!');
+
+    debug('Imported NProgress files!');
   }
 };

--- a/index.js
+++ b/index.js
@@ -11,7 +11,11 @@ module.exports = {
 
     debug('Importing NProgress files!');
 
-    app.import(app.bowerDirectory + '/nprogress/nprogress.js');
+    app.import(app.bowerDirectory + '/nprogress/nprogress.js', {
+      using: [
+        { transformation: 'amd', as: 'nprogress' }
+      ]
+    });
     app.import(app.bowerDirectory + '/nprogress/nprogress.css');
 
     debug('Imported NProgress files!');

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:testall"
+    "test": "ember try:each"
   },
+  "author": "Jason D. Jimenez",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/smashweaver/ember-cli-nprogress.git"
@@ -18,37 +20,36 @@
   "engines": {
     "node": ">= 0.10.0"
   },
-  "author": "Jason D. Jimenez",
-  "license": "MIT",
-  "devDependencies": {
-    "broccoli-asset-rev": "^2.2.0",
-    "ember-ajax": "0.7.1",
-    "ember-cli": "2.4.1",
-    "ember-cli-app-version": "^1.0.0",
-    "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars": "^1.0.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-qunit": "^1.2.1",
-    "ember-cli-release": "0.2.8",
-    "ember-cli-sri": "^2.1.0",
-    "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.4.0",
-    "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-disable-proxy-controllers": "^1.0.1",
-    "ember-export-application-global": "^1.0.4",
-    "ember-load-initializers": "^0.5.0",
-    "ember-resolver": "^2.0.3",
-    "ember-try": "^0.1.2",
-    "loader.js": "^4.0.0"
-  },
   "keywords": [
     "ember-addon",
     "nprogress"
   ],
+  "devDependencies": {
+    "broccoli-asset-rev": "^2.4.5",
+    "ember-cli": "2.10.0",
+    "ember-cli-app-version": "^2.0.0",
+    "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-htmlbars": "^1.0.10",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-jshint": "^2.0.1",
+    "ember-cli-qunit": "^3.0.1",
+    "ember-cli-release": "^0.2.9",
+    "ember-cli-sri": "^2.1.0",
+    "ember-cli-test-loader": "^1.1.0",
+    "ember-cli-uglify": "^1.2.0",
+    "ember-disable-prototype-extensions": "^1.1.0",
+    "ember-export-application-global": "^1.0.5",
+    "ember-load-initializers": "^0.5.1",
+    "ember-resolver": "^2.0.3",
+    "loader.js": "^4.0.10"
+  },
   "dependencies": {
     "debug": "^2.3.3",
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.7"
+  },
+  "engines": {
+    "node": ">= 0.12.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "nprogress"
   ],
   "dependencies": {
+    "debug": "^2.3.3",
     "ember-cli-babel": "^5.1.5"
   },
   "ember-addon": {

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -47,6 +47,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "unused": true
 }

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,16 +9,16 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="assets/vendor.js"></script>
-    <script src="assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import config from './config/environment';
 
 const Router = Ember.Router.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.rootURL
 });
 
 Router.map(function() {

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -4,12 +4,16 @@ module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'dummy',
     environment: environment,
-    baseURL: '/',
+    rootURL: '/',
     locationType: 'auto',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
+      },
+      EXTEND_PROTOTYPES: {
+        // Prevent Ember Data from overriding Date.parse.
+        Date: false
       }
     },
 
@@ -29,7 +33,6 @@ module.exports = function(environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.baseURL = '/';
     ENV.locationType = 'none';
 
     // keep test console output quieter

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,6 +1,9 @@
 import { module } from 'qunit';
+import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
+
+const { RSVP: { Promise } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {
@@ -8,16 +11,13 @@ export default function(name, options = {}) {
       this.application = startApp();
 
       if (options.beforeEach) {
-        options.beforeEach.apply(this, arguments);
+        return options.beforeEach.apply(this, arguments);
       }
     },
 
     afterEach() {
-      if (options.afterEach) {
-        options.afterEach.apply(this, arguments);
-      }
-
-      destroyApp(this.application);
+      let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
+      return Promise.resolve(afterEach).then(() => destroyApp(this.application));
     }
   });
 }

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -5,8 +5,8 @@ import config from '../../config/environment';
 export default function startApp(attrs) {
   let application;
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  // use defaults, but you can override
+  let attributes = Ember.assign({}, config.APP, attrs);
 
   Ember.run(() => {
     application = Application.create(attributes);

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,9 +10,9 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
-    <link rel="stylesheet" href="assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
@@ -21,12 +21,11 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="testem.js" integrity=""></script>
-    <script src="assets/vendor.js"></script>
-    <script src="assets/test-support.js"></script>
-    <script src="assets/dummy.js"></script>
-    <script src="assets/tests.js"></script>
-    <script src="assets/test-loader.js"></script>
+    <script src="/testem.js" integrity=""></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}

--- a/tests/unit/utils/nprogress-test.js
+++ b/tests/unit/utils/nprogress-test.js
@@ -3,6 +3,12 @@ import { module, test } from 'qunit';
 
 module('Unit | Utility | nprogress');
 
-test('it imports the `nprogress` object', function(assert) {
-  assert.ok(nprogress);
+test('it exports the `nprogress` object', function(assert) {
+  assert.ok(nprogress, 'Exports library');
+  assert.ok(nprogress.start, 'Has `start` method');
+  assert.ok(nprogress.done, 'Has `done` method');
+});
+
+test('it does not expose a global object', function(assert) {
+  assert.notOk(window['Nprogress']);
 });

--- a/tests/unit/utils/nprogress-test.js
+++ b/tests/unit/utils/nprogress-test.js
@@ -1,0 +1,8 @@
+import nprogress from 'ember-cli-nprogress';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | nprogress');
+
+test('it imports the `nprogress` object', function(assert) {
+  assert.ok(nprogress);
+});


### PR DESCRIPTION
Hey! Our company has pulled `ember-cli-nprogress` into a few of our projects and in the process, noticed a few improvements that could be made.  Namely, `nprogress` doesn't currently play too nicely with the Ember run loop, which is something that I'm hoping to fix.

However, before I do that, I wanted to lay the groundwork by adding some tests.  This PR does that, along with avoiding the "global" object that gets created by `nprogress` by importing it as an AMD module.  However, anonymous AMD modules are only supported by Ember CLI `2.9.0` and higher, so I updated that while I was in there.