### PR TITLE
Better runloop integration

### DIFF
--- a/addon/initializers/nprogress.js
+++ b/addon/initializers/nprogress.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+import nprogress from 'ember-cli-nprogress';
+
+const { run } = Ember;
+
+export const scheduler = run.later.bind(undefined, undefined);
+
+export function initialize() {
+  nprogress.configure({ scheduler });
+}
+
+export default {
+  name: 'nprogress',
+  initialize
+};

--- a/app/initializers/nprogress.js
+++ b/app/initializers/nprogress.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'ember-cli-nprogress/initializers/nprogress';

--- a/blueprints/ember-cli-nprogress/index.js
+++ b/blueprints/ember-cli-nprogress/index.js
@@ -2,6 +2,6 @@ module.exports = {
   normalizeEntityName: function() {}, // no-op since we're just adding dependencies
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('nprogress', '^0.2.0');
+    return this.addBowerPackageToProject('nprogress', 'alexlafroscia/nprogress#allow-alternate-scheduler');
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "dependencies": {
     "ember": "~2.10.0",
     "ember-cli-shims": "0.1.3",
-    "nprogress": "^0.2.0"
+    "nprogress": "alexlafroscia/nprogress#allow-alternate-scheduler"
   }
 }

--- a/tests/acceptance/run-loop-test.js
+++ b/tests/acceptance/run-loop-test.js
@@ -1,0 +1,30 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+import nprogress from 'ember-cli-nprogress';
+
+// Note: This somewhat unorthidox test setup will throw an error when running the tests in Chrome,
+// if `nprogress` isn't configured to run within the Ember run loop
+moduleForAcceptance('Acceptance | run loop', {
+  beforeEach() {
+    nprogress.configure({
+      parent: '#nprogress-parent'
+    });
+  }
+});
+
+test('loading an initial route', function(assert) {
+  assert.expect(0);
+
+  visit('/');
+});
+
+test('it fires the `start` event within the run loop', function(assert) {
+  visit('/');
+
+  click('a');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/some-other-route');
+  });
+});

--- a/tests/acceptance/run-loop-test.js
+++ b/tests/acceptance/run-loop-test.js
@@ -13,12 +13,15 @@ moduleForAcceptance('Acceptance | run loop', {
   }
 });
 
+// This is required to get the app set up
 test('loading an initial route', function(assert) {
   assert.expect(0);
 
   visit('/');
 });
 
+// This test just verifies that an error is not produced in cases where `nprogress`
+// is running while the app is being torn down
 test('it fires the `start` event within the run loop', function(assert) {
   visit('/');
 

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('some-other-route');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+import nprogress from 'ember-cli-nprogress';
+
+const { Route } = Ember;
+
+export default Route.extend({
+  actions: {
+    willTransition() {
+      nprogress.start();
+    },
+
+    didTransition() {
+      nprogress.done();
+    }
+  }
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,3 @@
-<h2 id="title">Welcome to Ember</h2>
+<div id='nprogress-parent'></div>
 
 {{outlet}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,0 +1,3 @@
+<h1>Hello, world!</h1>
+
+{{link-to 'Some other route' 'some-other-route'}}

--- a/tests/dummy/app/templates/some-other-route.hbs
+++ b/tests/dummy/app/templates/some-other-route.hbs
@@ -1,0 +1,2 @@
+<h1>Some Other Route</h1>
+

--- a/tests/unit/initializers/nprogress-test.js
+++ b/tests/unit/initializers/nprogress-test.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+
+import NprogressInitializer from 'dummy/initializers/nprogress';
+import { scheduler } from 'ember-cli-nprogress/initializers/nprogress';
+import nprogress from 'ember-cli-nprogress';
+
+let application;
+
+module('Unit | Initializer | nprogress', {
+  beforeEach() {
+    Ember.run(function() {
+      application = Ember.Application.create();
+      application.deferReadiness();
+    });
+  }
+});
+
+test('it sets up an Ember-friendly scheduler function', function(assert) {
+  NprogressInitializer.initialize(application);
+
+  assert.equal(nprogress.settings.scheduler, scheduler);
+});


### PR DESCRIPTION
To get `nprogress` to play nicely with the run loop, `nprogress` shouldn't use `window.setTimeout`.  However, it does not provide any way to do that...

... until now!  I forked `nprogress` and added support for a custom scheduler function; the PR for that can be found [here](https://github.com/rstacruz/nprogress/pull/161).  I have no idea if, or when, that is going to be accepted, so for the time being I added my fork as a dependency of the project.  Considering the lack of movement on the PRs that are already open on that repo, it may be a long time, but if it's ever closed then I'll update the Bower version in this addon, too.