### PR TITLE
Don't import nprogress when in fastboot

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,12 +10,15 @@ module.exports = {
     this._super.included(app);
 
     debug('Importing NProgress files!');
+   
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      app.import(app.bowerDirectory + '/nprogress/nprogress.js', {
+        using: [
+          { transformation: 'amd', as: 'nprogress' }
+        ]
+      });
+    }
 
-    app.import(app.bowerDirectory + '/nprogress/nprogress.js', {
-      using: [
-        { transformation: 'amd', as: 'nprogress' }
-      ]
-    });
     app.import(app.bowerDirectory + '/nprogress/nprogress.css');
 
     debug('Imported NProgress files!');


### PR DESCRIPTION
Document is undefined when running in fastboot