### PR TITLE
Adds fastboot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ ember install ember-cli-nprogress
 ### Showing `NProgress` while a model loads
 ```javascript
 import Ember from 'ember';
-import progress from 'ember-cli-nprogress';
+import nprogress from 'nprogress';
 
 export default Ember.Route.extend({
   model(params){
-    progress.start();
+    nprogress.start();
 
     let promise = this.store.findRecord('post', params.id);
     return promise.then(function(post){
-      progress.done();
+      nprogress.done();
       return post;
     });
   }

--- a/addon/initializers/nprogress.js
+++ b/addon/initializers/nprogress.js
@@ -4,7 +4,9 @@ import nprogress from 'nprogress';
 export const scheduler = run.later.bind(undefined, undefined);
 
 export function initialize() {
-  nprogress.configure({ scheduler });
+  if (typeof FastBoot === 'undefined') {
+    nprogress.configure({ scheduler });
+  }
 }
 
 export default {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4022,6 +4022,14 @@
         }
       }
     },
+    "fastboot-transform": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fastboot-transform/-/fastboot-transform-0.1.2.tgz",
+      "integrity": "sha512-SU343Ca3XeiGHxSvycVb3062ejN68Go8OXcx4QWgUUMek43XRUr/LuU4ILSxAMvvHvhamsSQivysWBEO9ux4oA==",
+      "requires": {
+        "broccoli-stew": "1.5.0"
+      }
+    },
     "faye-websocket": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "debug": "^2.3.3",
     "ember-cli-babel": "^6.6.0",
+    "fastboot-transform": "^0.1.2",
     "nprogress": "alexlafroscia/nprogress#allow-alternate-scheduler"
   },
   "devDependencies": {

--- a/vendor/nprogress-shim.js
+++ b/vendor/nprogress-shim.js
@@ -1,0 +1,12 @@
+(function() {
+
+  function generateModule(name, values) {
+    define(name, [], function() {
+      'use strict';
+
+      return values;
+    });
+  }
+
+  generateModule('nprogress', { 'default': window.NProgress });
+})();


### PR DESCRIPTION
Manually shims NProgress
wraps the NProgress lib in the support `fastboot-transform` lib
Changes the required way to import this lib as `import nprogress from 'nprogress';` instead of `import nprogress from 'ember-cli-nprogress';` as it was previous.
Updates README.md with the proper way to import this lib

Ensures that the NProgress lib does not init in fastboot land, but also ensures that initializer from the consuming app will still have something to import 'nprogress' from.